### PR TITLE
Handle null and inconsistent role names

### DIFF
--- a/src/main/java/com/AAA/demo/entities/Role.java
+++ b/src/main/java/com/AAA/demo/entities/Role.java
@@ -27,12 +27,27 @@ public class Role {
     )
     private String name;
 
-    public void setName(String name) {
+    public String getName() {
+        return name;
+    }
 
-        if(name.equalsIgnoreCase("Admin") || name.equalsIgnoreCase("Technician") || name.equalsIgnoreCase("User"))
-        this.name = name;
-        else
-            this.name = "Invalid";
+    public void setName(String name) {
+        if (name != null) {
+            String trimmed = name.trim();
+            if (trimmed.equalsIgnoreCase("Admin")) {
+                this.name = "Admin";
+                return;
+            }
+            if (trimmed.equalsIgnoreCase("Technician")) {
+                this.name = "Technician";
+                return;
+            }
+            if (trimmed.equalsIgnoreCase("User")) {
+                this.name = "User";
+                return;
+            }
+        }
+        this.name = "Invalid";
     }
 
 

--- a/src/test/java/com/AAA/demo/entities/RoleTest.java
+++ b/src/test/java/com/AAA/demo/entities/RoleTest.java
@@ -1,0 +1,34 @@
+package com.AAA.demo.entities;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class RoleTest {
+    @Test
+    void setNameAcceptsValidRoles() {
+        Role role = new Role();
+        assertDoesNotThrow(() -> role.setName("Admin"));
+        assertEquals("Admin", role.getName());
+    }
+
+    @Test
+    void setNameCanonicalizesCase() {
+        Role role = new Role();
+        role.setName("uSeR");
+        assertEquals("User", role.getName());
+    }
+
+    @Test
+    void setNameTrimsWhitespace() {
+        Role role = new Role();
+        role.setName("  Technician  ");
+        assertEquals("Technician", role.getName());
+    }
+
+    @Test
+    void setNameWithNullDefaultsToInvalid() {
+        Role role = new Role();
+        assertDoesNotThrow(() -> role.setName(null));
+        assertEquals("Invalid", role.getName());
+    }
+}


### PR DESCRIPTION
## Summary
- prevent `Role.setName` from throwing when given null by validating input
- normalize and trim role names to avoid duplicates due to case or whitespace
- add getter for role name and expand tests for case/whitespace/null inputs

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b321ca0094832d8275eb94ea9a7abf